### PR TITLE
Solved Issue #19: Tasks in AWS ECS are not stopped after CI/CD Pipeline finished

### DIFF
--- a/gitlab_ci_fargate_runner/gitlab_ci_fargate_runner_stack.py
+++ b/gitlab_ci_fargate_runner/gitlab_ci_fargate_runner_stack.py
@@ -125,7 +125,8 @@ class GitlabCiFargateRunnerStack(cdk.Stack):
                             effect=iam.Effect.ALLOW,
                             actions=[
                                 "ecs:DescribeTasks",
-                                "ecs:RunTask"
+                                "ecs:RunTask",
+                                "ecs:StopTask"
                             ],
                             resources=["*"]
                         ),


### PR DESCRIPTION
*Issue #19 

*Description of changes: Added "ecs:StopTask" permission to the fargate_servie_runner.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
